### PR TITLE
Update __init__.py to work on virtualenvs

### DIFF
--- a/showme/__init__.py
+++ b/showme/__init__.py
@@ -1,1 +1,4 @@
-from core import *
+try:
+    from .core import *
+except ImportError:
+    from core import *


### PR DESCRIPTION
In some virtual environments of python >3.5 to import a from the same directory inside a package requires to prepend the name with a dot